### PR TITLE
PHP7.2 is currently required

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,16 @@ Content manipulation system for building websites
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://hotglue.me)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://hotglue.me/demo/)
-[![Version: 1.04~ynh3](https://img.shields.io/badge/Version-1.04~ynh3-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/hotglue/)
+[![Version: 1.04~ynh3](https://img.shields.io/badge/Version-1.04~ynh3-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/hotglue/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/hotglue"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>
 <a href="https://github.com/YunoHost-Apps/hotglue_ynh/issues"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_report_an_issue.svg"/></a>
 </div>
+
+
+## Screenshots
+![Screenshot of Hotglue](./doc/screenshots/screenshot.jpg)
 
 ## 📦 Developer info
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -66,4 +66,4 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages = "php8.3-gd"
+    packages = "php8.2-gd"

--- a/manifest.toml
+++ b/manifest.toml
@@ -66,4 +66,4 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages = "php8.2-gd"
+    packages = "php7.4-gd"

--- a/manifest.toml
+++ b/manifest.toml
@@ -54,7 +54,7 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/k0a1a/hotglue2/archive/refs/tags/dev-release.tar.gz"
+    url = "https://github.com/k0a1a/hotglue2/archive/refs/tags/release.tar.gz"
     sha256 = "8152c8cffaad57be03b33326d0939f12935a1fbd57718410d33e689e9eca6336"
 
     [resources.system_user]
@@ -66,4 +66,4 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages = "php-gd"
+    packages = "php8.2-gd"

--- a/manifest.toml
+++ b/manifest.toml
@@ -66,4 +66,4 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages = "php8.2-gd"
+    packages = "php7.2-gd"

--- a/manifest.toml
+++ b/manifest.toml
@@ -66,4 +66,4 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages = "php7.4-gd"
+    packages = "php-gd"

--- a/manifest.toml
+++ b/manifest.toml
@@ -55,7 +55,7 @@ ram.runtime = "50M"
 
     [resources.sources.main]
     url = "https://github.com/k0a1a/hotglue2/archive/refs/tags/release.tar.gz"
-    sha256 = "8152c8cffaad57be03b33326d0939f12935a1fbd57718410d33e689e9eca6336"
+    sha256 = "48fe7d5c6075a9729da038ad46e154a86a6c7f644306d88db761413cbbeeae4d"
 
     [resources.system_user]
     


### PR DESCRIPTION
## Problem

- *PHP8 dropped get_magic_quotes_gpc() call*
- 
Fatal error: Uncaught Error: Call to undefined function get_magic_quotes_gpc()

## Solution

- *Using PHP7.2 for the time being until it is fixed upstream*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
